### PR TITLE
Feature/hive metastore init warehouse

### DIFF
--- a/recipes/hadoop_yarn.rb
+++ b/recipes/hadoop_yarn.rb
@@ -22,8 +22,8 @@ package 'mapr-hadoop-core'
 
 # yarn-site.xml, mapred-site.xml
 %w(mapred_site yarn_site).each do |sitefile|
-  template "#{sitefile.gsub('_', '-')}.xml" do
-    path lazy { "#{hadoop_conf_dir}/#{sitefile.gsub('_', '-')}.xml" }
+  template "#{sitefile.tr('_', '-')}.xml" do
+    path lazy { "#{hadoop_conf_dir}/#{sitefile.tr('_', '-')}.xml" }
     source 'generic-site.xml.erb'
     mode '0644'
     owner 'root'

--- a/recipes/hbase.rb
+++ b/recipes/hbase.rb
@@ -20,7 +20,7 @@
 # Ensure conf directory exists
 package 'mapr-hbase'
 
-template "hbase-site.xml" do
+template 'hbase-site.xml' do
   path lazy { "#{hbase_conf_dir}/hbase-site.xml" }
   source 'generic-site.xml.erb'
   mode '0644'

--- a/recipes/hive.rb
+++ b/recipes/hive.rb
@@ -25,7 +25,7 @@ package pkg do
   action :install
 end
 
-template "hive-site.xml" do
+template 'hive-site.xml' do
   path lazy { "#{hive_conf_dir}/hive-site.xml" }
   source 'generic-site.xml.erb'
   mode '0644'

--- a/recipes/hive_metastore.rb
+++ b/recipes/hive_metastore.rb
@@ -55,7 +55,7 @@ unless scratch_dir == '/tmp/hive-${user.name}'
     timeout 300
     user m_user
     group m_group
-    not_if "hadoop fs -test -d #{scratch_dir}", :user => m_user
+    not_if "hadoop fs -test -d #{scratch_dir}", user: m_user
     action :nothing
   end
 end
@@ -65,6 +65,6 @@ execute 'hive-mfs-warehousedir' do
   timeout 300
   user m_user
   group m_group
-  not_if "hadoop fs -test -d #{warehouse_dir}", :user => m_user
+  not_if "hadoop fs -test -d #{warehouse_dir}", user: m_user
   action :nothing
 end


### PR DESCRIPTION
- [x] resources to create hive metastore warehouse and scratch directories.  largely copied from hadoop cookbook (modified user/group and 'hadoop fs' command invocations).
- [x] style fixes
