### PR TITLE
check any subdir of expected hive location

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -54,11 +54,11 @@ module HadoopMapr
     def hive_conf_dir
       result = nil
       # There is no hiveversion file, we can only guess and check
-      Dir.foreach('/opt/mapr/hive') do |candidate|
+      ::Dir.foreach('/opt/mapr/hive') do |candidate|
         next if candidate == '.' || candidate == '..'
-        next unless File.directory?(File.join('/opt/mapr/hive', candidate))
-        if ::File.exist?(File.join('/opt/mapr/hive', candidate, 'conf', 'hive-site.xml'))
-          result = File.join('/opt/mapr/hive', candidate, 'conf')
+        next unless ::File.directory?(::File.join('/opt/mapr/hive', candidate))
+        if ::File.exist?(::File.join('/opt/mapr/hive', candidate, 'conf', 'hive-site.xml'))
+          result = ::File.join('/opt/mapr/hive', candidate, 'conf')
           break
         end
       end


### PR DESCRIPTION
examines any directory under `/opt/mapr/hive` to find the hive conf directory, instead of just checking a few known versions.  This works for mapr5.0/hive1.2
