### PR TITLE
lwrp direct support for no-autostart flag

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -59,6 +59,9 @@ action :run do
   # client_only_mode
   args += ['-c'] if new_resource.client_only_mode == true
 
+  # no-autostart
+  args += ['-no-autostart'] if new_resource.no_autostart == true
+
   # additional args
   additional_args = new_resource.args || []
   # Flatten any hashes or multi-level arrays within additional_args to arrays

--- a/resources/configure.rb
+++ b/resources/configure.rb
@@ -35,6 +35,8 @@ attribute :cluster_name,          kind_of: String,                    default: n
 attribute :refresh_roles,         kind_of: [TrueClass, FalseClass],   default: false
 # -c
 attribute :client_only_mode,      kind_of: [TrueClass, FalseClass],   default: false
+# -no-autostart
+attribute :no_autostart,          kind_of: [TrueClass, FalseClass],   default: false
 
 # Additional args will simply be flattened and passed through as args to configure.sh
 #   example input: [ '--isvm', { '-HS': 'hostA' } ]


### PR DESCRIPTION
adds an LWRP attribute for `-no-autostart`, as it frequently needs to be set.
