### PR TITLE
add chefspec matcher for configure lwrp

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: hadoop_mapr
+# Library:: matchers
+#
+# Copyright © 2015 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if defined?(ChefSpec)
+  ChefSpec.define_matcher :hadoop_mapr_configure
+  def run_hadoop_mapr_configure(cluster_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:hadoop_mapr_configure, :run, cluster_name)
+  end
+end


### PR DESCRIPTION
add chefspec matcher for the `configure` lwrp.  allows other cookbooks to test against this lwrp.
