### PR TITLE
apply tmpdir creation logic only for the mapr_user

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -69,20 +69,12 @@ hadoop_tmp_dir =
 node.default['hadoop']['core_site']['hadoop.tmp.dir'] = hadoop_tmp_dir
 
 if node['hadoop']['core_site']['hadoop.tmp.dir'] == 'file:///tmp/hadoop-${user}'
-  %w(mapr mapreduce yarn).each do |dir|
-    directory "/tmp/hadoop-#{dir}" do
-      mode '1777'
-      my_user =
-        if dir == 'mapreduce'
-          'mapred'
-        else
-          dir
-        end
-      owner my_user
-      group my_user
-      action :create
-      recursive true
-    end
+  directory "/tmp/hadoop-#{node['hadoop_mapr']['mapr_user']['username']}" do
+    mode '1777'
+    owner node['hadoop_mapr']['mapr_user']['username']
+    group node['hadoop_mapr']['mapr_user']['group']
+    action :create
+    recursive true
   end
 elsif node['hadoop']['core_site']['hadoop.tmp.dir'] =~ /${user}/
   # Since we're creating a 1777 directory, Hadoop can create the user-specific subdirectories, itself

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -25,12 +25,10 @@ describe 'hadoop_mapr::default' do
       expect(link).to link_to('/some/data/disk')
     end
 
-    %w(hadoop-mapr hadoop-mapreduce hadoop-yarn).each do |dir|
-      it "creates /tmp/#{dir} directory" do
-        expect(chef_run).to create_directory("/tmp/#{dir}").with(
-          mode: '1777'
-        )
-      end
+    it 'creates /tmp/hadoop-mapr directory' do
+      expect(chef_run).to create_directory('/tmp/hadoop-mapr').with(
+        mode: '1777'
+      )
     end
   end
 


### PR DESCRIPTION
- [x] the borrowed `hadoop.tmp.dir` logic was problematic, since under mapr everything runs as the same 'mapr' user.
