### PR TITLE
spark packages support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,5 @@ AsciiComments:
   Enabled: false
 Style/SpaceBeforeFirstArg:
   Enabled: false
+Metrics/BlockLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,5 @@ LineLength:
   Max: 500
 AsciiComments:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,11 @@ group :integration do
   cookbook 'java', '~> 1.21'
 end
 
+# Restrict version due to Chef 12 requirement
+if RUBY_VERSION.to_f < 2.0
+  cookbook 'apt', '< 4.0'
+  cookbook 'build-essential', '< 3.0'
+  cookbook 'ohai', '< 4.0'
+end
+
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,24 +1,43 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf', '~> 3.0'
-gem 'foodcritic', '~> 4.0'
 
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
+if RUBY_VERSION.to_f < 2.2
+  gem 'rack', '< 2.0'
+  if RUBY_VERSION.to_f < 2.1
+    gem 'fauxhai', '< 3.5'
+  else
+    gem 'fauxhai', '< 3.10'
+  end
+end
+
+if RUBY_VERSION.to_f < 2.1
+  gem 'buff-ignore', '< 1.2'
+  gem 'chef-zero', '< 4.6'
+  gem 'ffi-yajl', '< 2.3'
+  gem 'dep_selector', '< 1.0.4'
+  gem 'net-http-persistent', '< 3.0'
+end
+
 if RUBY_VERSION.to_f < 2.0
   gem 'chef', '< 12.0'
+  gem 'json', '< 2.0'
+  gem 'rubocop', '< 0.42'
   gem 'varia_model', '< 0.5.0'
+  gem 'foodcritic', '~> 4.0'
 else
-  gem 'chef', '< 12.5' # Testing
+  gem 'chef', '< 12.5'
+  gem 'foodcritic', '~> 6.0'
+  gem 'rubocop'
 end
 
 gem 'ridley', '~> 4.2.0'
 gem 'faraday', '< 0.9.2'
-
-gem 'rubocop'
-gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'
+gem 'dep-selector-libgecode', '< 1.3.1'
 
 group :integration do
   gem 'test-kitchen'

--- a/recipes/spark.rb
+++ b/recipes/spark.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: hadoop_mapr
+# Recipe:: spark
+#
+# Copyright © 2013-2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'hadoop_mapr::default'
+
+package 'mapr-spark' do
+  action :install
+  version node['spark']['version'] if node.key?('spark') && node['spark'].key?('version') && !node['spark']['version'].empty?
+end

--- a/recipes/spark_historyserver.rb
+++ b/recipes/spark_historyserver.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: hadoop_mapr
+# Recipe:: spark_historyserver
+#
+# Copyright © 2013-2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'hadoop_mapr::spark'
+pkg = 'mapr-spark-historyserver'
+
+# This is the default hard-coded into MapR spark package postinstall scripts.
+eventlog_dir = 'hdfs:///apps/spark'
+
+execute 'hdfs-spark-eventlog-dir' do
+  command "hdfs dfs -mkdir -p #{eventlog_dir} && hdfs dfs -chown -R spark:spark #{eventlog_dir} && hdfs dfs -chmod 1777 #{eventlog_dir}"
+  user 'hdfs'
+  group 'hdfs'
+  timeout 300
+  action :nothing
+end
+
+package pkg do
+  action :install
+  version node['spark']['version'] if node.key?('spark') && node['spark'].key?('version') && !node['spark']['version'].empty?
+end

--- a/recipes/spark_master.rb
+++ b/recipes/spark_master.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: hadoop_mapr
+# Recipe:: spark_master
+#
+# Copyright © 2013-2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'hadoop_mapr::spark'
+pkg = 'mapr-spark-master'
+
+package pkg do
+  action :install
+  version node['spark']['version'] if node.key?('spark') && node['spark'].key?('version') && !node['spark']['version'].empty?
+end


### PR DESCRIPTION
- [x] basic recipes for ``mapr-spark``, ``mapr-spark-historyserver``, & ``mapr-spark-master`` package installs.  follows http://maprdocs.mapr.com/home/AdvancedInstallation/InstallSparkonYARN.html
- [ ] no configuration customization for now... mapr packages do things like have postinstall scripts append hardcoded values to spark-defaults.conf, which essentially discourages customization in the first place.